### PR TITLE
General improvements in memory repos

### DIFF
--- a/infrastructure/repositories/book/in_memory_book_repository.py
+++ b/infrastructure/repositories/book/in_memory_book_repository.py
@@ -7,22 +7,22 @@ from domain.repositories.book_repository import BookRepository
 class InMemoryBookRepository(BookRepository):
     
     def __init__(self) -> None:
-        self.books: List[Book] = []
+        self.__books: List[Book] = []
     
     
     def save(self, book: Book) -> None:
         if self.get_by_id(book.id) is None:    
-            self.books.append(book)
+            self.__books.append(book)
             return
         self.update(book)
     
     
     def get_all(self) -> List[Book]:
-        return self.books
+        return self.__books
 
 
     def get_by_id(self, id: str) -> Optional[Book]:
-        for book in self.books:
+        for book in self.__books:
             if book.id == id:
                 return book
 
@@ -31,13 +31,13 @@ class InMemoryBookRepository(BookRepository):
         if not self.get_by_id(book.id):    
             raise BookNotFound()
         
-        for index, stored_book in enumerate(self.books):
+        for index, stored_book in enumerate(self.__books):
             if stored_book.id == book.id:
-                self.books[index] = book
+                self.__books[index] = book
         
     
     
     def delete(self, book_id: str) -> None:
-        for book in self.books:
+        for book in self.__books:
             if book.id == book_id:
-                self.books.remove(book)
+                self.__books.remove(book)

--- a/infrastructure/repositories/book/in_memory_book_repository.py
+++ b/infrastructure/repositories/book/in_memory_book_repository.py
@@ -18,7 +18,7 @@ class InMemoryBookRepository(BookRepository):
     
     
     def get_all(self) -> List[Book]:
-        return self.__books
+        return [book for book in self.__books]
 
 
     def get_by_id(self, id: str) -> Optional[Book]:

--- a/infrastructure/repositories/book/in_memory_book_repository.py
+++ b/infrastructure/repositories/book/in_memory_book_repository.py
@@ -28,12 +28,12 @@ class InMemoryBookRepository(BookRepository):
 
 
     def update(self, book: Book) -> None:
-        if not self.get_by_id(book.id):    
-            raise BookNotFound()
-        
         for index, stored_book in enumerate(self.__books):
             if stored_book.id == book.id:
                 self.__books[index] = book
+                break
+        
+        raise BookNotFound()
         
     
     
@@ -41,3 +41,4 @@ class InMemoryBookRepository(BookRepository):
         for book in self.__books:
             if book.id == book_id:
                 self.__books.remove(book)
+                break

--- a/infrastructure/repositories/user/in_memory_user_repository.py
+++ b/infrastructure/repositories/user/in_memory_user_repository.py
@@ -28,15 +28,16 @@ class InMemoryUserRepository(UserRepository):
 
 
     def update(self, user: User):
-        if not self.get_by_id(user.id):    
-            raise UserNotRegistered()
-        
         for index, stored_user in enumerate(self.__users):
             if stored_user.id == user.id:
                 self.__users[index] = user
+                break
+        
+        raise UserNotRegistered()
     
     
     def delete(self, id: str) -> None:
         for user in self.__users:
             if user.id == id:
                 self.__users.remove(user)
+                break

--- a/infrastructure/repositories/user/in_memory_user_repository.py
+++ b/infrastructure/repositories/user/in_memory_user_repository.py
@@ -14,9 +14,7 @@ class InMemoryUserRepository(UserRepository):
         if self.get_by_id(user.id) is None:    
             self.__users.append(user)
             return
-        for index, stored_user in enumerate(self.__users):
-            if stored_user.id == user.id:
-                self.__users[index] = user
+        self.update(user)
     
     
     def get_all(self) -> List[User]:

--- a/infrastructure/repositories/user/in_memory_user_repository.py
+++ b/infrastructure/repositories/user/in_memory_user_repository.py
@@ -18,7 +18,7 @@ class InMemoryUserRepository(UserRepository):
     
     
     def get_all(self) -> List[User]:
-        return self.__users
+        return [user for user in self.__users]
 
     
     def get_by_id(self, id: str) -> Optional[User]:

--- a/infrastructure/repositories/user/in_memory_user_repository.py
+++ b/infrastructure/repositories/user/in_memory_user_repository.py
@@ -7,24 +7,24 @@ from domain.repositories.user_repository import UserRepository
 class InMemoryUserRepository(UserRepository):
     
     def __init__(self) -> None:
-        self.users: List[User] = []
+        self.__users: List[User] = []
     
     
     def save(self, user: User) -> None:
         if self.get_by_id(user.id) is None:    
-            self.users.append(user)
+            self.__users.append(user)
             return
-        for index, stored_user in enumerate(self.users):
+        for index, stored_user in enumerate(self.__users):
             if stored_user.id == user.id:
-                self.users[index] = user
+                self.__users[index] = user
     
     
     def get_all(self) -> List[User]:
-        return self.users
+        return self.__users
 
     
     def get_by_id(self, id: str) -> Optional[User]:
-        for user in self.users:
+        for user in self.__users:
             if user.id == id:
                 return user
 
@@ -33,12 +33,12 @@ class InMemoryUserRepository(UserRepository):
         if not self.get_by_id(user.id):    
             raise UserNotRegistered()
         
-        for index, stored_user in enumerate(self.users):
+        for index, stored_user in enumerate(self.__users):
             if stored_user.id == user.id:
-                self.users[index] = user
+                self.__users[index] = user
     
     
     def delete(self, id: str) -> None:
-        for user in self.users:
+        for user in self.__users:
             if user.id == id:
-                self.users.remove(user)
+                self.__users.remove(user)


### PR DESCRIPTION
Basically each change was made for the 2 different kind of repos, users and books:
- Lists visibility changed to private, to avoid unexpected operations
- The `get_all` method returns a copy of the list instead of the list itself. Same reason as above
- Optimized loops by leveraging flow control statements like `break`
    - Specifically for the `update` methods, the logic used `get_by_id` followed by a loop, resulting in effectively looping twice. Now, it performs a single loop through the data, and once the target is found and updated, it exits early using `break`. If the loop completes without finding the target, it raises an exception.