### PR TITLE
Mejorado el manejo de cursores de SQLite

### DIFF
--- a/infrastructure/repositories/book/sqlite_book_repository.py
+++ b/infrastructure/repositories/book/sqlite_book_repository.py
@@ -10,60 +10,55 @@ from infrastructure.repositories.book.queries import BookQueries as BQ
 class SQLiteBookRepository(BookRepository):
     def __init__(self, db_path: str = "books.db") -> None:
         self.__conn: Connection = sqlite3.connect(db_path)
-        self.__cursor: Cursor = self.__conn.cursor()
         
-        self.__cursor.execute(BQ.CREATE_TABLE.value)
+        self.__conn.execute(BQ.CREATE_TABLE.value)
         self.__conn.commit()
-
-
-    def commit_and_close(self) -> None:
-        self.__conn.commit()
-        self.__cursor.close()
   
   
     def is_table_empty(self) -> bool:
-        self.__cursor.execute("SELECT * FROM book")
-        return self.__cursor.fetchone() is None
+        cursor: Cursor = self.__conn.execute("SELECT * FROM book")
+        is_empty = cursor.fetchone() is None
+        cursor.close()
+        return is_empty
     
     
     def save(self, book: Book) -> None:
         if self.get_by_id(book.id) is None: 
-            self.__cursor.execute(
+            self.__conn.execute(
                 BQ.INSERT.value,
                 (book.id, book.title, book.author, book.availability)
                 )
+            self.__conn.commit()
         else:
             self.update(book)
-        self.commit_and_close()
 
     def get_all(self) -> List[Book]:
-        self.__cursor.execute(BQ.GET_ALL.value)
-        rows: list[Any] = self.__cursor.fetchall()
+        cursor: Cursor = self.__conn.execute(BQ.GET_ALL.value)
+        rows: list[Any] = cursor.fetchall()
+        cursor.close()
         books: List[Book] = [
             Book(id=row[0], title=row[1], author=row[2], availability=bool(row[3]))
             for row in rows
             ]
-        self.commit_and_close()
         return books
     
     
     def get_by_id(self, id: str) -> Optional[Book]:
-        self.__cursor.execute(BQ.GET_BY_ID.value, (id,))
-        row = self.__cursor.fetchone()
+        cursor: Cursor = self.__conn.execute(BQ.GET_BY_ID.value, (id,))
+        row = cursor.fetchone()
+        cursor.close()
         if row:
             return Book(id=row[0], title=row[1], author=row[2], availability=bool(row[3]))
-        self.__conn.commit()
-        
     
     
     def update(self, book: Book) -> None:
-        self.__cursor.execute(
+        self.__conn.execute(
             BQ.UPDATE.value,
             (book.title, book.author, book.availability, book.id)
             )
-        self.commit_and_close()
+        self.__conn.commit()
     
     
     def delete(self, book_id: str) -> None:
-        self.__cursor.execute(BQ.DELETE.value, (book_id,))
-        self.commit_and_close()
+        self.__conn.execute(BQ.DELETE.value, (book_id,))
+        self.__conn.commit()

--- a/infrastructure/repositories/user/sqlite_user_repository.py
+++ b/infrastructure/repositories/user/sqlite_user_repository.py
@@ -10,47 +10,45 @@ from infrastructure.repositories.user.queries import UserQueries as UQ
 class SQLiteuserRepository(UserRepository):
     def __init__(self, db_path: str = "users.db") -> None:
         self.__conn: Connection = sqlite3.connect(db_path)
-        self.__cursor: Cursor = self.__conn.cursor()
+        cursor: Cursor = self.__conn.cursor()
         
-        self.__cursor.execute(UQ.CREATE_TABLE.value)
+        cursor.execute(UQ.CREATE_TABLE.value)
         self.__conn.commit()
-
-
-    def commit_and_close(self) -> None:
-        self.__conn.commit()
-        self.__cursor.close()
-  
+        cursor.close()
   
     def is_table_empty(self) -> bool:
-        self.__cursor.execute("SELECT * FROM users")
-        return self.__cursor.fetchone() is None
+        cursor: Cursor = self.__conn.execute("SELECT * FROM users")
+        is_empty = cursor.fetchone() is None
+        cursor.close()
+        return is_empty
     
     
     def save(self, user: User) -> None:
         if self.get_by_id(user.id) is None: 
-            self.__cursor.execute(
+            self.__conn.execute(
                 UQ.INSERT.value,
                 (user.id, user.name, user.reputation)
                 )
+            self.__conn.commit()
         else:
             self.update(user)
-        self.commit_and_close()
 
     
     def get_all(self) -> List[User]:
-        self.__cursor.execute(UQ.GET_ALL.value)
-        rows: List[Any] = self.__cursor.fetchall()
+        cursor: Cursor = self.__conn.execute(UQ.GET_ALL.value)
+        rows: List[Any] = cursor.fetchall()
+        cursor.close()
         users: List[User] = [
             User(id=row[0], name=row[1], reputation=row[2])
             for row in rows
             ]
-        self.commit_and_close()
         return users
     
     
     def get_by_id(self, id: str) -> Optional[User]:
-        self.__cursor.execute(UQ.GET_BY_ID.value, (id,))
-        row = self.__cursor.fetchone()
+        cursor: Cursor = self.__conn.execute(UQ.GET_BY_ID.value, (id,))
+        row = cursor.fetchone()
+        cursor.close()
         if row:
             return User(id=row[0], name=row[1], reputation=row[2])
         self.__conn.commit()
@@ -58,13 +56,13 @@ class SQLiteuserRepository(UserRepository):
     
     
     def update(self, user: User) -> None:
-        self.__cursor.execute(
+        self.__conn.execute(
             UQ.UPDATE.value,
             (user.name, user.reputation, user.id)
             )
-        self.commit_and_close()
+        self.__conn.commit()
     
     
     def delete(self, id: str) -> None:
-        self.__cursor.execute(UQ.DELETE.value, (id,))
-        self.commit_and_close()
+        self.__conn.execute(UQ.DELETE.value, (id,))
+        self.__conn.commit()


### PR DESCRIPTION
Crear un cursor para cada operación y cerrarlo manualmente es un approach menos problemático que crear un cursor en el constructor del repo y re-aprovecharlo siempre. Si una consulta falla, el cursor puede guardar estado relacionado con eso, el cuál no se está manejando en ningún método y puede dar problemas